### PR TITLE
Allow digits in module names

### DIFF
--- a/Idris.tmLanguage
+++ b/Idris.tmLanguage
@@ -41,7 +41,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(module)\s+([a-zA-Z._']+)$</string>
+			<string>^(module)\s+([a-zA-Z0-9._']+)$</string>
 			<key>name</key>
 			<string>meta.declaration.module.idris</string>
 		</dict>
@@ -55,7 +55,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(import)\s+([a-zA-Z._']+)$</string>
+			<string>^(import)\s+([a-zA-Z0-9._']+)$</string>
 			<key>name</key>
 			<string>meta.import.idris</string>
 		</dict>


### PR DESCRIPTION
This is allowed in Idris 2 (and I think also in Idris 1), and it's keeping things like `import Data.List1` from highlighting correctly ([example](https://github.com/lynn/aoc-2020/blob/f91441c6a9cdd29f59012a6885f9bed769a01c87/day-13.idr)).